### PR TITLE
Add: railsとmysqlをdocker環境に変更

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM ruby:3.1.2
+ARG ROOT="/api"
+ENV LANG=C.UTF-8
+ENV TZ=Asia/Tokyo
+
+RUN apt-get update
+RUN apt-get install -y build-essential \
+  libpq-dev \
+  sudo
+
+WORKDIR ${ROOT}
+
+COPY Gemfile ${ROOT}
+COPY Gemfile.lock ${ROOT}
+
+RUN gem install bundler
+RUN bundle install
+
+COPY entrypoint.sh /usr/bin/
+RUN chmod +x /usr/bin/entrypoint.sh
+ENTRYPOINT ["entrypoint.sh"]
+EXPOSE 3000
+
+CMD ["rails", "server", "-b", "0.0.0.0"]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -217,6 +217,8 @@ GEM
     net-smtp (0.3.3)
       net-protocol
     nio4r (2.5.8)
+    nokogiri (1.13.9-aarch64-linux)
+      racc (~> 1.4)
     nokogiri (1.13.9-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.13.9-x86_64-linux)
@@ -361,6 +363,7 @@ GEM
     zeitwerk (2.6.6)
 
 PLATFORMS
+  aarch64-linux
   arm64-darwin-21
   x86_64-linux
 

--- a/config/database.yml
+++ b/config/database.yml
@@ -13,9 +13,10 @@ default: &default
   adapter: mysql2
   encoding: utf8mb4
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-  username: root
-  password: ptr2839
-  host: localhost
+  username: <%= ENV['DB_USERNAME'] %>
+  password: <%= ENV['DB_PASSWORD'] %>
+  socket: /tmp/mysql.sock
+  host: db
 
 development:
   <<: *default

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,29 @@
+version: "3.9"
+services:
+  db:
+    image: mysql:8.0
+    platform: linux/amd64
+    command: --default-authentication-plugin=mysql_native_password
+    volumes:
+      - mysql_data:/var/lib/mysql
+    environment:
+      MYSQL_ROOT_PASSWORD: ENV['DB_PASSWORD']
+      TZ: "Asia/Tokyo"
+    ports:
+      - "3306:3306"
+  web:
+    build: .
+    command: bash -c "rm -f tmp/pids/server.pid && bundle exec rails s -p 3000 -b '0.0.0.0'"
+    volumes:
+      - .:/api:cached
+      - bundle:/usr/local/bundle
+    ports:
+      - 3000:3000
+    depends_on:
+      - db
+    tty: true
+    stdin_open: true
+
+volumes:
+  bundle:
+  mysql_data:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+
+# Remove a potentially pre-existing server.pid for Rails.
+rm -f /myapp/tmp/pids/server.pid
+
+# Then exec the container's main process (what's set as CMD in the Dockerfile).
+exec "$@"


### PR DESCRIPTION
## 概要

デプロイをスムーズに行うため、railsとmysqlの環境をdockerに変更