### PR TITLE
Add: raise_delivery_errorsをfalseにして動作を確認

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -87,6 +87,8 @@ Rails.application.configure do
 
   config.action_mailer.delivery_method = :smtp
 
+  config.action_mailer.perform_deliveries = true
+
   config.action_mailer.smtp_settings = {
     address: ENV['SMTP_ADDRESS'],
     port: ENV['SMTP_PORT'],

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -71,7 +71,7 @@ Rails.application.configure do
   # Use default logging formatter so that PID and timestamp are not suppressed.
   config.log_formatter = ::Logger::Formatter.new
 
-  config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.raise_delivery_errors = true
 
   # Use a different logger for distributed setups.
   # require "syslog/logger"
@@ -83,7 +83,7 @@ Rails.application.configure do
     config.logger    = ActiveSupport::TaggedLogging.new(logger)
   end
 
-  config.action_mailer.default_url_options = { host: 'valofinder.com' }
+  config.action_mailer.default_url_options = { host: 'valofinder.com', protcol: 'https' }
 
   config.action_mailer.delivery_method = :smtp
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -71,6 +71,8 @@ Rails.application.configure do
   # Use default logging formatter so that PID and timestamp are not suppressed.
   config.log_formatter = ::Logger::Formatter.new
 
+  config.action_mailer.raise_delivery_errors = false
+
   # Use a different logger for distributed setups.
   # require "syslog/logger"
   # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new "app-name")


### PR DESCRIPTION
## 概要

本番環境で新規登録が上手く行かず、エラーには`internal Server Error`を確認
とりあえずraise_delivery_errorsをfalseにしてメールに関するエラーを発生させない状態で動作を確認する。
